### PR TITLE
Support OSX

### DIFF
--- a/app/scripts/Util/HuisDev.ts
+++ b/app/scripts/Util/HuisDev.ts
@@ -11,8 +11,6 @@
 
 			var TAG = "Util.HuisDev";
 
-			var usb_dev = require("usb_dev");
-
 			interface IDiffInfo	{
 				diff: string[];
 				dir1Extra: string[];
@@ -721,7 +719,7 @@
 			 * @return {string} vendorId, productId となるデバイするのルートパスを返す。見つからない場合は null
 			 */
 			export function	getHuisRootPath(vendorId: number, productId: number): string {
-				var	rootPath = usb_dev.getPath(vendorId, productId);
+				var	rootPath = null
 				if (rootPath === "") {
 					return null;
 				}

--- a/app/scripts/init.ts
+++ b/app/scripts/init.ts
@@ -152,10 +152,11 @@ module Garage {
         DESCRIPTION_EXTENSION_HUIS_IMPORT_EXPORT_REMOTE = "リモコンファイル";
 
 		// Garage のファイルのルートパス設定 (%APPDATA%\Garage)
-		GARAGE_FILES_ROOT = path.join(app.getPath("appData"), "Garage").replace(/\\/g, "/");
+		GARAGE_FILES_ROOT = "/tmp/garage"
 		// HUIS File のルートパス設定 (%APPDATA%\Garage\HuisFiles)
 		HUIS_FILES_ROOT = path.join(GARAGE_FILES_ROOT, "HuisFiles").replace(/\\/g, "/");
 		if (!fs.existsSync(HUIS_FILES_ROOT)) {
+			fs.mkdirSync(GARAGE_FILES_ROOT);
 			fs.mkdirSync(HUIS_FILES_ROOT);
 		}
         REMOTE_IMAGES_DIRRECOTORY_NAME = "remoteimages";
@@ -268,7 +269,7 @@ module Garage {
 	var initCheck = (callback?: Function) => {
 		HUIS_ROOT_PATH = null;
 		while (!HUIS_ROOT_PATH) {
-			HUIS_ROOT_PATH = Util.HuisDev.getHuisRootPath(HUIS_VID, HUIS_PID);
+			HUIS_ROOT_PATH = "/Volumes/HUIS-100RC"
 
             if (HUIS_ROOT_PATH) { // HUISデバイスが接続されている
                 let dirs = null;

--- a/app/stylesheets/_base.scss
+++ b/app/stylesheets/_base.scss
@@ -59,7 +59,7 @@ body {
 			display: none;	
 	}
 				
-	//ƒ‰ƒxƒ‹Aƒ{ƒ^ƒ“A‰æ‘œ‚È‚Ç‚Ìz-indexƒAƒCƒeƒ€
+	//ãƒ©ãƒ™ãƒ«ã€ãƒœã‚¿ãƒ³ã€ç”»åƒãªã©ã®z-indexã‚¢ã‚¤ãƒ†ãƒ 
 	.label-item{
 		z-index:3;	
 	}
@@ -73,7 +73,7 @@ body {
 	}
 
 
-    //ƒXƒNƒ[ƒ‹ƒo[
+    //ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼
     ::-webkit-scrollbar {
         &:horizontal{
             height: $SIZE_SCROLL_BAR_WHOLE_HEIGHT;
@@ -88,7 +88,7 @@ body {
     #face-canvas, #face-pallet, #face-list{     
         ::-webkit-scrollbar{
             &:vertical{
-                //ƒXƒP[ƒ‹‚ª1/2‚È‚Ì‚Å‚Q”{‚É
+                //ã‚¹ã‚±ãƒ¼ãƒ«ãŒ1/2ãªã®ã§ï¼’å€ã«
                 width:$SIZE_SCROLL_BAR_VERTICL_WHOLE_WIDTH*2;
             }
         }
@@ -100,11 +100,11 @@ body {
         //overflow :overlay;
     }
 
-    //–îˆóƒ{ƒ^ƒ“‚ğ”ñ•\¦‚ÉB
+    //çŸ¢å°ãƒœã‚¿ãƒ³ã‚’éè¡¨ç¤ºã«ã€‚
     ::-webkit-scrollbar-button:no-button{
     }
 
-    //ƒXƒNƒ[ƒ‹ƒo[‚ÌƒNƒŠƒbƒN‰Â”\ƒGƒŠƒA
+    //ã‚¹ã‚¯ãƒ­ãƒ¼ãƒ«ãƒãƒ¼ã®ã‚¯ãƒªãƒƒã‚¯å¯èƒ½ã‚¨ãƒªã‚¢
     ::-webkit-scrollbar-thumb {
         &:hover{
             background-color: $COLOR_SCROLL_BAR_HOVER;
@@ -127,7 +127,7 @@ body {
         }
 
         &:vertical{
-			//ƒXƒP[ƒ‹‚ª1/2‚È‚Ì‚Å‚Q”{‚É
+			//ã‚¹ã‚±ãƒ¼ãƒ«ãŒ1/2ãªã®ã§ï¼’å€ã«
             border-left : $SIZE_SCROLL_BAR_BORDER_VERTICAL_LEFT* 2 solid $COLOR_SCROLL_BAR_THUMB_PADDING ;
 			border-right : $SIZE_SCROLL_BAR_BORDER_HORIZONTAL_RIGHT* 2 solid $COLOR_SCROLL_BAR_THUMB_PADDING ;
 			border-bottom : $SIZE_SCROLL_BAR_BORDER_VERTICAL_BOTTOM *2 solid $COLOR_SCROLL_BAR_THUMB_PADDING;
@@ -156,7 +156,7 @@ body {
     .ui-page-theme-b{
 	
 
-        //‹¤’Ê‚Ì‚«o‚µ
+        //å…±é€šã®å¹ãå‡ºã—
         #popup-arrow{
             background-position:center;
             background-repeat: no-repeat;
@@ -168,7 +168,7 @@ body {
 			margin-bottom:$SIZE_POPUP_ARROW_MINUS_MARGIN_BOTTOM;
         }
 
-        //‹¤’Ê‚ÌƒeƒLƒXƒgƒ{ƒ^ƒ“
+        //å…±é€šã®ãƒ†ã‚­ã‚¹ãƒˆãƒœã‚¿ãƒ³
           .ui-btn{
                 font-family:$FONT_FAMILY_TEXT_BUTTON;
                 text-shadow:none;
@@ -232,7 +232,7 @@ body {
                 }
             }
 
-            //‹¤’Ê‚Ìƒvƒ‹ƒ_ƒEƒ“ƒƒjƒ…[
+            //å…±é€šã®ãƒ—ãƒ«ãƒ€ã‚¦ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼
         .ui-select {
             -webkit-appearance: none;
             margin-top:$SIZE_PULL_DOWM_MARGIN_TOP;
@@ -291,7 +291,7 @@ body {
 
             }
 
-            //pull down menu‚Ì‘I‘ğˆ
+            //pull down menuã®é¸æŠè‚¢
             .ui-selectmenu{
                 margin-top:$SIZE_PULL_DOWM_MARGIN_MAIN_AND_SUB;
                 margin-bottom:$SIZE_PULL_DOWM_MARGIN_MAIN_AND_SUB;
@@ -319,7 +319,7 @@ body {
                         height:$SIZE_PULL_DOWM_HEIGHT_SUB;
 
                         .ui-btn, ui-btn-active{
-                            //c’†‰›‘µ‚¦
+                            //ç¸¦ä¸­å¤®æƒãˆ
                             display: flex;
                             align-items: center;
 
@@ -346,7 +346,7 @@ body {
            }
 
 
-            //ƒIƒvƒVƒ‡ƒ“ƒƒjƒ…[
+            //ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼
             #option-pulldown-menu{
                 background-image:$PATH_IMG_OPTION_MENU_BTN_NORMAL;
                 margin-top:$SIZE_HEADER_OPTION_BTN_MARGIN_TOP;
@@ -368,7 +368,7 @@ body {
                 }
             }
                  
-            //ƒIƒvƒVƒ‡ƒ“ƒƒjƒ…[‚Ìƒ|ƒbƒvƒAƒbƒv
+            //ã‚ªãƒ—ã‚·ãƒ§ãƒ³ãƒ¡ãƒ‹ãƒ¥ãƒ¼ã®ãƒãƒƒãƒ—ã‚¢ãƒƒãƒ—
             .ui-popup-container{
 
                 ul{
@@ -445,7 +445,7 @@ body {
             z-index: 2;
         }
 
-        //‹¤’Ê‚ÌƒeƒLƒXƒgƒtƒB[ƒ‹ƒh
+        //å…±é€šã®ãƒ†ã‚­ã‚¹ãƒˆãƒ•ã‚£ãƒ¼ãƒ«ãƒ‰
         input[type="text"]{
             font-family:$FONT_FAMILY_TEXT_BUTTON;
             height:$SIZE_FORM_HEIGHT;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "main": "main.js",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "node-ini": "^1.0.0",
-    "usb_dev": "https://github.com/sony/node-win-usbdev.git"
+    "node-ini": "^1.0.0"
   }
 }


### PR DESCRIPTION
OSXで動作するように変更を加えたバージョンです。

変更によりWindows環境ではビルドが通らないフォークとなっています。
将来的にはnode-win-usbdev側を修正することで、Mac/Win両対応となるよう修正したほうが良いかもしれません。

## ビルド方法

基本的にはWindowsの時と同様ですが、以下の違いに考慮する必要があります。

1. node-gypでのネイティブコンパイルはスキップ
2. electron-packagerを以下のコマンドで実行

```
electron-packager . huis --platform=darwin --arch=x64 --version=1.2.5 --ignore="node_modules/(grunt*|electron-rebuild)" --ignore=".git" --ignore="Service References" --ignore="docs" --ignore="obj" --ignore="tests/*" --ignore="www" --ignore="platforms" --ignore="-x64$" --ignore="-ia32$"
```